### PR TITLE
修复文件名中含有" | "等特殊字符时文件转换失败的问题

### DIFF
--- a/ximalaya.pl
+++ b/ximalaya.pl
@@ -116,7 +116,7 @@ sub download_m4a {
 sub convert_m4a_to_mp3 {
 	my $title = shift;
 	print "converting $title.m4a to $title.mp3 ...\n";
-	my $ret = system("/usr/local/bin/ffmpeg -loglevel 24 -i $title.m4a -map 0:a -codec:a libmp3lame -q:a 4 -map_metadata -1 $title.mp3");
+	my $ret = system("/usr/local/bin/ffmpeg -loglevel 24 -i '$title.m4a' -map 0:a -codec:a libmp3lame -q:a 4 -map_metadata -1 '$title.mp3'");
 	if ($ret != 0) {
 		print "convert $title.m4a to $title.mp3 failed\n";
 		unlink($title.".m4a");


### PR DESCRIPTION
修复文件名中含有" ' | "等特殊字符时文件转换失败的问题。
当获取的文件名中含有特殊字符时，在system调用中，shell会将特殊字符转义而导致失败。